### PR TITLE
Enable call recording for Austria

### DIFF
--- a/java/com/android/dialer/callrecord/res/values-mcc232/config.xml
+++ b/java/com/android/dialer/callrecord/res/values-mcc232/config.xml
@@ -15,5 +15,5 @@
      limitations under the License.
 -->
 <resources>
-    <bool name="call_recording_enabled">false</bool>
+    <bool name="call_recording_enabled">true</bool>
 </resources>


### PR DESCRIPTION
Call recording is legal in Austria, so it should be availble in the UI (if enabled per device in java/com/android/dialer/callrecord/res/values/config.xml).