### PR TITLE
Allow call recording for Russia

### DIFF
--- a/java/com/android/dialer/callrecord/res/values-mcc250/config.xml
+++ b/java/com/android/dialer/callrecord/res/values-mcc250/config.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+     Copyright (C) 2014 The CyanogenMod Project
+
+     Licensed under the Apache License, Version 2.0 (the "License");
+     you may not use this file except in compliance with the License.
+     You may obtain a copy of the License at
+
+          http://www.apache.org/licenses/LICENSE-2.0
+
+     Unless required by applicable law or agreed to in writing, software
+     distributed under the License is distributed on an "AS IS" BASIS,
+     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     See the License for the specific language governing permissions and
+     limitations under the License.
+-->
+
+<!--Allow recording for country: Russia-->
+<!--Legal precedent source: The definition of the JC in civil cases of the Supreme Court of the Russian Federation of December 6, 2016 N 35-KG16-18, http://www.supcourt.ru/stor_pdf.php?id=1502686 -->
+<resources>
+
+</resources>


### PR DESCRIPTION
 * Call recording is legal in Russia, so it should be available in the UI