### PR TITLE
Allow call recording for Belgium

### DIFF
--- a/java/com/android/dialer/callrecord/res/values-mcc206/config.xml
+++ b/java/com/android/dialer/callrecord/res/values-mcc206/config.xml
@@ -16,8 +16,7 @@
 -->
 
 <!--Allow recording for country: Belgium-->
-<!--Summary of legal articles and legal precedents by the Justice Minister in 2002, https://www.lachambre.be/kvvcr/showpage.cfm?section=qrva&language=fr&cfm=qrvaXml.cfm?legislat=50&dossierID=50-b157-17-0588-2001200200913.xml 
-Confirmed by legal precedents in 2008, http://www.wbcj.be/Publications/Enregistrement-d%E2%80%99une-conversation-par-un-participa.aspx-->
+<!--Summary of legal articles and legal precedents : QRVA 50 157, Page 20199, 24/02/2003, https://www.lachambre.be/QRVA/pdf/50/50K0157.pdf-->
 <resources>
 
 </resources>

--- a/java/com/android/dialer/callrecord/res/values-mcc206/config.xml
+++ b/java/com/android/dialer/callrecord/res/values-mcc206/config.xml
@@ -14,6 +14,10 @@
      See the License for the specific language governing permissions and
      limitations under the License.
 -->
+
+<!--Allow recording for country: Belgium-->
+<!--Summary of legal articles and legal precedents by the Justice Minister in 2002, https://www.lachambre.be/kvvcr/showpage.cfm?section=qrva&language=fr&cfm=qrvaXml.cfm?legislat=50&dossierID=50-b157-17-0588-2001200200913.xml 
+Confirmed by legal precedents in 2008, http://www.wbcj.be/Publications/Enregistrement-d%E2%80%99une-conversation-par-un-participa.aspx-->
 <resources>
-    <bool name="call_recording_enabled">false</bool>
+
 </resources>


### PR DESCRIPTION
* Call recording is legal in Belgium, so it should be available in the UI
* Precedents links provided show that the use of recordings is legal in most cases, although this should be checked case-by-case

As for the Iaae0b222d2a1108572832732471e7e063f84dd1f change-id, I added two links that summarize relevant law articles & legal precedents (from the Justice Minister in 2002, with an update from a lawyer cabinet in 2008)